### PR TITLE
feat(cli): cli reads txt files given by -u flag and stores in datastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ include/
 lib/
 lib64
 share/
-pyenv.cfg
+pyvenv.cfg
+*.txt

--- a/cli.py
+++ b/cli.py
@@ -1,14 +1,46 @@
 import argparse
+import json
+import ast
+import os
 
 parser = argparse.ArgumentParser(description='Import a new dataset or query the datastore')
 parser.add_argument('-s', '--select', help='Specify columns to be selected')
 parser.add_argument('-o', '--order', help='Specify order in which to display results')
 parser.add_argument('-f', '--filter', help='Specify filter to use on results')
-parser.add_argument('-i', '--import', help='Specify path of file to import')
+parser.add_argument('-u', '--upload', help='Specify path of file to upload')
 
 def main():
   args = parser.parse_args()
-  print(args)
+  if (args.upload):
+    if (os.path.isfile('./RecordSet.txt')):
+      with open('./RecordSet.txt', 'r') as rs:
+        recordSet = eval(rs.read())
+    else:
+      recordSet = {}
+    try:
+      with open(args.upload, 'r') as newRecordSet:
+        records = newRecordSet.read().strip().split('\n')
+        records.pop(0)
+    except FileNotFoundError:
+      print('Invalid file path')
+  else:
+    print('no file')
+  try:
+    for record in records:
+      recordDetails = record.split('|')
+      recordID = recordDetails[0] + recordDetails[1] + recordDetails[2]
+      recordSet[recordID] = {
+          'stb': recordDetails[0],
+          'title': recordDetails[1],
+          'provider': recordDetails[2],
+          'date': recordDetails[3],
+          'rev': recordDetails[4],
+          'view_time': recordDetails[5]
+      }
+  except:
+    print('Input file improperly formatted')
+  with open('./RecordSet.txt', 'w') as rs:
+    rs.write(str(recordSet))
 
 if __name__ == '__main__':
   main()

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /usr/bin
-include-system-site-packages = false
-version = 3.6.7


### PR DESCRIPTION
Description: if the -u flag is used and a path argument is provided, the cli
will now attempt to read the comments of the file at that path, throwing
an appropriate exception if the file is not found or not in the correct format.
If the file is found and in the correct format, the datastore in RecordSet.txt
will be updated. This operation is idempotent, with unique records being
identified by the combination of their STB, TITLE, and DATE, if a record uniquely
identified thusly is already present and a new record is uploaded with the same
unique identifier, this record will be overwritten by the new one, whether or not
the other fields hold the same values.

Todo: This code is complex and verbose enough that it should probably be extracted
into its own module before we add any additional functionality. Also, there should
be some more error checking around reading from and writing to RecordStore.txt, and
we could probably refactor our current Try/Except blocks to include them, so that we
don't have to open RecordStore twice.